### PR TITLE
fix: Add missing error callback

### DIFF
--- a/src/plugin/callbackTypes.ts
+++ b/src/plugin/callbackTypes.ts
@@ -38,6 +38,14 @@ export interface CodePopupResponse {
   scope: string;
 }
 
+export interface ErrorPopupResponse {
+  message: string;
+  /** The error stack trace. */
+  stack: string;
+  /** The error type, giving the detailed reason for the error. */
+  type: string;
+}
+
 /**
  * Callback triggered with JWT credential response on google login prompts success.
  */

--- a/src/plugin/types.ts
+++ b/src/plugin/types.ts
@@ -362,6 +362,17 @@ export interface CodeClientConfig {
    * Optional, defaults to 'false'. Boolean value to prompt the user to select an account
    */
   select_account?: boolean;
+
+  /**
+   * Optional. The JavaScript function that handles some non-OAuth errors, such as the popup window is failed to open; or closed before an OAuth response is returned.
+   * 
+   * The `type` field of the input parameter gives the detailed reason.
+   * 
+   *   * popup_failed_to_open The popup window is failed to open.
+   *   * popup_closed The popup window is closed before an OAuth response is returned.
+   *   * unknown Placeholder for other errors.
+   */
+  error_callback?: (errorResponse: callbackTypes.ErrorPopupResponse) => void;
 }
 
 /** This variable holds an access to google client SDK */


### PR DESCRIPTION
Add missing `error_callback` in [CodeClientConfig](https://developers.google.com/identity/oauth2/web/reference/js-reference#CodeClientConfig)